### PR TITLE
Fix schema test to match actual table order

### DIFF
--- a/t/schema.t
+++ b/t/schema.t
@@ -19,6 +19,7 @@ my $schema = PerlDiver::Schema->get_schema();
 isa_ok($schema, 'PerlDiver::Schema');
 
 my $tables = $dbh->selectcol_arrayref('SELECT name FROM sqlite_master WHERE type="table"');
-is_deeply($tables, [qw(file repo run run_file)], 'Correct tables in database');
+my @expected_tables = qw(repo file run run_file);
+is_deeply([sort @$tables], [sort @expected_tables], 'Correct tables in database');
 
 done_testing;


### PR DESCRIPTION
Fixes #19

Update the test in `t/schema.t` to match the actual order of tables in the database.

* Change the expected order of tables in the test 'Correct tables in database' to: 'repo', 'file', 'run', 'run_file'.
* Sort both the expected list and the returned list to ensure they are in the same order.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/app-perldiver/issues/19?shareId=9eaac040-e08f-4771-9b27-89ead4ea9349).