### PR TITLE
Get the database connection information from PerlDiver::Config

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -18,3 +18,4 @@ requires 'Test::Exception';
 requires 'Test::LWP::UserAgent';
 requires 'Test::More';
 requires 'URI';
+requires 'YAML::XS';

--- a/lib/App/PerlDiver.pm
+++ b/lib/App/PerlDiver.pm
@@ -55,7 +55,8 @@ has schema => (
 );
 
 sub _build_schema {
-  return PerlDiver::Schema->get_schema;
+  my $self = shift;
+  return PerlDiver::Schema->get_schema($self->config);
 }
 
 has tt => (

--- a/lib/PerlDiver/Config.pm
+++ b/lib/PerlDiver/Config.pm
@@ -4,10 +4,10 @@ class PerlDiver::Config {
 
   use YAML::XS 'LoadFile';
 
-  field $database;
-  field $type;
-  field $user;
-  field $pass;
+  field $database :reader;
+  field $type :reader;
+  field $user :reader;
+  field $pass :reader;
 
   method load_config {
     my $config_data = LoadFile('perldiver.yml');

--- a/lib/PerlDiver/Config.pm
+++ b/lib/PerlDiver/Config.pm
@@ -5,10 +5,20 @@ class PerlDiver::Config {
   use YAML::XS 'LoadFile';
 
   field $database;
+  field $type;
+  field $user;
+  field $pass;
 
   method load_config {
     my $config_data = LoadFile('perldiver.yml');
     $database = $config_data->{database};
+    $type = $config_data->{type};
+    $user = $config_data->{user};
+    $pass = $config_data->{pass};
+  }
+
+  method dsn {
+    return "dbi:$type:dbname=$database";
   }
 }
 

--- a/lib/PerlDiver/Schema.pm
+++ b/lib/PerlDiver/Schema.pm
@@ -10,7 +10,6 @@ extends 'DBIx::Class::Schema';
 
 __PACKAGE__->load_namespaces;
 
-
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2022-11-08 18:05:35
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:n/czIebb5x2gqLteRODsqg
 
@@ -18,10 +17,14 @@ __PACKAGE__->load_namespaces;
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);
 
+use PerlDiver::Config;
+
 sub get_schema {
     my $self = shift;
-    my $config = shift || 'db/perldiver.conf';
-    return $self->connect($config);
+    my ($config) = @_;
+    $config //= PerlDiver::Config->new;
+    $config->load_config;
+    return $self->connect($config->dsn, $config->user, $config->pass);
 }
 
 1;

--- a/perldiver.yml
+++ b/perldiver.yml
@@ -1,1 +1,4 @@
 database: db/perldiver.db
+type: SQLite
+user: ""
+pass: ""


### PR DESCRIPTION
Fixes #28

Update `PerlDiver::Schema` to use `PerlDiver::Config` for database connection information.

* Modify `lib/PerlDiver/Schema.pm`:
  - Add `use PerlDiver::Config`.
  - Update `get_schema` method to use `PerlDiver::Config` to get the database connection information.
  - Remove the default configuration file path from `get_schema` method.
  - Use `my $self = shift` in `get_schema`.

* Modify `lib/PerlDiver/Config.pm`:
  - Add `type`, `user`, and `pass` attributes.
  - Update `load_config` method to load `type`, `user`, and `pass` from `perldiver.yml`.
  - Add `dsn` method to construct the DSN string.

* Modify `lib/App/PerlDiver.pm`:
  - Update `_build_schema` method to pass the database connection information from `PerlDiver::Config` to `PerlDiver::Schema->get_schema`.

* Modify `perldiver.yml`:
  - Add `type`, `user`, and `pass` fields with appropriate values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/app-perldiver/issues/28?shareId=687b7ea8-1461-40e6-8a43-8965c2d8beaa).